### PR TITLE
Fix for empty files

### DIFF
--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -374,9 +374,9 @@
         var data = null;
         try {
           data = atob(e.target.result.split(',')[1]);
-        } catch(e) {
+        } catch(exception) {
           //If data is empty or undefined in cases such as an empty file
-          if(e.name = "InvalidCharacterError" && e.target.result.split(',')[1] == null) {
+          if(exception.name = "InvalidCharacterError" && e.target.result.split(',')[1] == null) {
             data = "";
           }
         }

--- a/jquery.filedrop.js
+++ b/jquery.filedrop.js
@@ -370,7 +370,17 @@
           xhr.withCredentials = opts.withCredentials;
         }
 
-        var data = atob(e.target.result.split(',')[1]);
+        //Patch for empty file use case
+        var data = null;
+        try {
+          data = atob(e.target.result.split(',')[1]);
+        } catch(e) {
+          //If data is empty or undefined in cases such as an empty file
+          if(e.name = "InvalidCharacterError" && e.target.result.split(',')[1] == null) {
+            data = "";
+          }
+        }
+        //End patch
         if (typeof newName === "string") {
           builder = getBuilder(newName, data, mime, boundary);
         } else {


### PR DESCRIPTION
If the file is empty, e.target.result.split(',')[1] === undefined, resulting in an invalid encoding error when method atob is triggered. Set a catch clause to catch empty files. and give it a default empty string.

Complete error:
DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded. {message: "Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.", name: "InvalidCharacterError", code: 5
